### PR TITLE
Alternative implementation for Path handling

### DIFF
--- a/src/ops.rs
+++ b/src/ops.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use flate2::write::GzEncoder;
 use flate2::Compression;
@@ -7,7 +7,6 @@ use fs_extra::{dir, file};
 use futures::Future;
 use handlebars::Handlebars;
 use hyper::client::connect::Connect;
-use path_slash::PathBufExt;
 use tempfile::tempdir;
 use tokio::runtime::current_thread::Runtime;
 use url::Url;
@@ -131,12 +130,9 @@ fn construct_rootfs(
     let mut file_copy_options = file::CopyOptions::new();
     file_copy_options.overwrite = true;
 
-    for path_map in manifest.path_maps() {
-        let (local_path, target_path) = path_map;
+    for (local_path, target_path) in manifest.path_maps() {
         let local_path = problem_dir.as_ref().join(local_path);
-        let target_path = PathBuf::from_slash(target_path);
-        let root = PathBuf::from_slash("/");
-        let destination = build_dir.as_ref().join(target_path.strip_prefix(root)?);
+        let destination = build_dir.as_ref().join(target_path.strip_prefix("/")?);
         // TODO: more descriptive error
         fs::create_dir_all(destination.parent().ok_or(SomaError::InvalidManifest)?)?;
         if local_path.is_dir() {


### PR DESCRIPTION
1. Windows Path도 슬래시로 끊긴 경로 잘 처리합니다. 단, Unix와 다르게 슬래시와 백슬래시에서 둘 다 끊기는데, `PathBufExt`의 `from_slash`도 내부 표현만 다를 뿐 동작은 동일합니다. 따라서 외부 crate 대신 std를 쓰는 원래 방향으로 변경했습니다.

2. #98의 취지가 String 대신 Path(Buf)를 쓰자인데, 오히려 String을 쓰는 부분이 늘어나고 인코딩-디코딩을 무의미하게 반복하는 부분이 있어 이를 원래 PathBuf 구현으로 되돌렸습니다.