### PR TITLE
Make Backend a trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,6 +396,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "curl-sys"
 version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,6 +446,14 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "erased-serde"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -556,6 +573,16 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ghost"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -703,6 +730,26 @@ dependencies = [
 name = "indexmap"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "inventory"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ctor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ghost 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "inventory-impl 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "inventory-impl"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "iovec"
@@ -1448,6 +1495,7 @@ dependencies = [
  "tempfile 3.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typetag 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "whoami 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1751,6 +1799,28 @@ version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "typetag"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "erased-serde 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "inventory 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typetag-impl 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "typetag-impl"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ucd-trie"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1959,10 +2029,12 @@ dependencies = [
 "checksum crossterm_terminal 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f1b61af4ef3ed3624994e8af7ac87b6a483c2936e63eebe38d9a2810cd4a6d44"
 "checksum crossterm_utils 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d26f24386ea91f9c55a85531dd3ee3673e4c82729e64567928665aca3a47c741"
 "checksum crossterm_winapi 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f63b02344710452064687251b49cb0c275df10ea70dcd6038b1eec11665efc0a"
+"checksum ctor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "9a43db2bba5cafdc6aa068c892a518e477ee0df3705e53ec70247a9ff93546d5"
 "checksum curl-sys 0.4.16 (registry+https://github.com/rust-lang/crates.io-index)" = "ca79238a79fb294be6173b4057c95b22a718c94c4e38475d5faa82b8383f3502"
 "checksum digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "03b072242a8cbaf9c145665af9d250c59af3b958f83ed6824e13533cf76d5b90"
 "checksum dirs 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "88972de891f6118092b643d85a0b28e0678e0f948d7f879aa32f2d5aafe97d2a"
 "checksum env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "afb070faf94c85d17d50ca44f6ad076bce18ae92f0037d350947240a36e9d42e"
+"checksum erased-serde 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "3beee4bc16478a1b26f2e80ad819a52d24745e292f521a63c16eea5f74b7eb60"
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
@@ -1979,6 +2051,7 @@ dependencies = [
 "checksum futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)" = "49e7653e374fe0d0c12de4250f0bdb60680b8c80eed558c5c7538eec9c89e21b"
 "checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
 "checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
+"checksum ghost 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5297b71943dc9fea26a3241b178c140ee215798b7f79f7773fd61683e25bca74"
 "checksum git2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c7339329bfa14a00223244311560d11f8f489b453fb90092af97f267a6090ab0"
 "checksum h2 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "ddb2b25a33e231484694267af28fec74ac63b5ccf51ee2065a5e313b834d836e"
 "checksum half 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9353c2a89d550b58fa0061d8ed8d002a7d8cdf2494eb0e432859bd3a9e543836"
@@ -1992,6 +2065,8 @@ dependencies = [
 "checksum hyperlocal 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d063d6d5658623c6ef16f452e11437c0e7e23a6d327470573fe78892dafbc4fb"
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
 "checksum indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7e81a7c05f79578dbc15793d8b619db9ba32b4577003ef3af1a91c416798c58d"
+"checksum inventory 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "21df85981fe094480bc2267723d3dc0fd1ae0d1f136affc659b7398be615d922"
+"checksum inventory-impl 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8a877ae8bce77402d5e9ed870730939e097aad827b2a932b361958fa9d6e75aa"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
 "checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
@@ -2104,6 +2179,8 @@ dependencies = [
 "checksum toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"
 "checksum try-lock 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
 "checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
+"checksum typetag 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "204be70778085341a7d3a0e8bb7330dd237ac5b7ea3eb29d1c201fa713510b43"
+"checksum typetag-impl 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f2fbb17a80fed21799f236d889dae74f1383f2da7241bb79708c26fd25f7b6bb"
 "checksum ucd-trie 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "71a9c5b1fe77426cf144cc30e49e955270f5086e31a6441dfa8b32efc09b9d77"
 "checksum ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ tar = "0.4.20"
 tempfile = "3.0.5"
 tokio = "0.1.15"
 toml = "0.4.10"
+typetag = "0.1.1"
 url = "1.7.2"
 whoami = "0.4.1"
 

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -1,18 +1,16 @@
 use std::collections::HashSet;
-use std::fmt;
 use std::path::{Path, PathBuf};
 
-use fs_extra::dir::{copy, CopyOptions};
-use git2::{BranchType, ObjectType, Repository as GitRepository, ResetType};
-use remove_dir_all::remove_dir_all;
 use serde::{Deserialize, Serialize};
 
 use crate::prelude::*;
 use crate::problem::{read_manifest, MANIFEST_FILE_NAME};
 use crate::read_file_contents;
+use crate::repository::backend::Backend;
 
 pub use self::manager::RepositoryManager;
 
+pub mod backend;
 mod manager;
 
 const LIST_FILE_NAME: &str = "soma-list.toml";
@@ -45,57 +43,9 @@ struct ProblemIndex {
     path: PathBuf,
 }
 
-#[derive(Clone, Deserialize, Serialize)]
-pub enum Backend {
-    GitBackend(String),
-    // On Windows, this path corresponds to extended length path
-    // which means we can only join backslash-delimited paths to it
-    LocalBackend(PathBuf),
-}
-
-impl Backend {
-    fn update_at(&self, local_path: impl AsRef<Path>) -> SomaResult<()> {
-        match &self {
-            Backend::GitBackend(url) => {
-                let git_repo = GitRepository::open(&local_path)
-                    .or_else(|_| GitRepository::clone(url, &local_path))?;
-                git_repo
-                    .find_remote("origin")?
-                    .fetch(&["master"], None, None)?;
-
-                let origin_master = git_repo.find_branch("origin/master", BranchType::Remote)?;
-                let head_commit = origin_master.get().peel(ObjectType::Commit)?;
-                git_repo.reset(&head_commit, ResetType::Hard, None)?;
-
-                Ok(())
-            }
-            Backend::LocalBackend(path) => {
-                if local_path.as_ref().exists() {
-                    remove_dir_all(&local_path)?;
-                }
-
-                let mut copy_options = CopyOptions::new();
-                copy_options.copy_inside = true;
-                copy(&path, &local_path, &copy_options)?;
-
-                Ok(())
-            }
-        }
-    }
-}
-
-impl fmt::Display for Backend {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Backend::GitBackend(url) => write!(f, "Git: {}", url),
-            Backend::LocalBackend(path) => write!(f, "Local: {}", path.to_string_lossy()),
-        }
-    }
-}
-
 pub struct Repository<'a> {
     name: String,
-    backend: Backend,
+    backend: Box<dyn Backend>,
     prob_list: Vec<ProblemIndex>,
     manager: &'a RepositoryManager<'a>,
 }
@@ -103,7 +53,7 @@ pub struct Repository<'a> {
 impl<'a> Repository<'a> {
     fn new(
         name: String,
-        backend: Backend,
+        backend: Box<dyn Backend>,
         prob_list: Vec<ProblemIndex>,
         manager: &'a RepositoryManager<'a>,
     ) -> Repository<'a> {
@@ -119,8 +69,8 @@ impl<'a> Repository<'a> {
         &self.name
     }
 
-    pub fn backend(&self) -> &Backend {
-        &self.backend
+    pub fn backend(&self) -> &dyn Backend {
+        &*self.backend
     }
 
     pub fn manager(&self) -> &'a RepositoryManager {
@@ -132,7 +82,7 @@ impl<'a> Repository<'a> {
     }
 
     pub fn update(&self) -> SomaResult<()> {
-        self.backend.update_at(self.path())
+        self.backend.update_at(&self.path())
     }
 
     pub fn prob_name_iter(&'a self) -> impl Iterator<Item = &'a String> {

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use crate::prelude::*;
 use crate::problem::{read_manifest, MANIFEST_FILE_NAME};
 use crate::read_file_contents;
-use crate::repository::backend::Backend;
+use crate::repository::backend::{Backend, BackendExt};
 
 pub use self::manager::RepositoryManager;
 
@@ -82,7 +82,7 @@ impl<'a> Repository<'a> {
     }
 
     pub fn update(&self) -> SomaResult<()> {
-        self.backend.update_at(&self.path())
+        self.backend.update_at(self.path())
     }
 
     pub fn prob_name_iter(&'a self) -> impl Iterator<Item = &'a String> {

--- a/src/repository/backend.rs
+++ b/src/repository/backend.rs
@@ -1,0 +1,134 @@
+use std::fmt::{self, Display};
+use std::fs::remove_dir_all;
+use std::path::{Path, PathBuf};
+
+use fs_extra::dir;
+use git2::{BranchType, ObjectType, Repository as GitRepository, ResetType};
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+use crate::prelude::*;
+
+#[typetag::serde(tag = "type")]
+pub trait Backend: BackendClone + Display {
+    fn update_at(&self, local_path: &Path) -> SomaResult<()>;
+}
+
+pub trait BackendClone {
+    fn clone_box(&self) -> Box<dyn Backend>;
+}
+
+impl<T> BackendClone for T
+where
+    T: 'static + Backend + Clone,
+{
+    fn clone_box(&self) -> Box<dyn Backend> {
+        Box::new(self.clone())
+    }
+}
+
+impl Clone for Box<dyn Backend> {
+    fn clone(&self) -> Box<dyn Backend> {
+        self.clone_box()
+    }
+}
+
+pub fn location_to_backend(repo_location: &str) -> SomaResult<(String, Box<dyn Backend>)> {
+    let path = Path::new(repo_location);
+    if path.is_dir() {
+        // local backend
+        Ok((
+            path.file_name()
+                .ok_or(SomaError::FileNameNotFound)?
+                .to_str()
+                .ok_or(SomaError::InvalidUnicode)?
+                .to_owned(),
+            Box::new(LocalBackend::new(path.canonicalize()?.to_owned())),
+        ))
+    } else {
+        // git backend
+        let parsed_url = Url::parse(repo_location).or(Err(SomaError::RepositoryNotFound))?;
+        let last_name = parsed_url
+            .path_segments()
+            .ok_or(SomaError::RepositoryNotFound)?
+            .last()
+            .ok_or(SomaError::FileNameNotFound)?;
+        let repo_name = if last_name.ends_with(".git") {
+            &last_name[..last_name.len() - 4]
+        } else {
+            &last_name
+        };
+        Ok((
+            repo_name.to_owned(),
+            Box::new(GitBackend::new(repo_location.to_owned())),
+        ))
+    }
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+pub struct GitBackend {
+    url: String,
+}
+
+impl GitBackend {
+    pub fn new(url: String) -> Self {
+        GitBackend { url }
+    }
+}
+
+#[typetag::serde]
+impl Backend for GitBackend {
+    fn update_at(&self, local_path: &Path) -> SomaResult<()> {
+        let git_repo = GitRepository::open(local_path)
+            .or_else(|_| GitRepository::clone(&self.url, local_path))?;
+        git_repo
+            .find_remote("origin")?
+            .fetch(&["master"], None, None)?;
+
+        let origin_master = git_repo.find_branch("origin/master", BranchType::Remote)?;
+        let head_commit = origin_master.get().peel(ObjectType::Commit)?;
+        git_repo.reset(&head_commit, ResetType::Hard, None)?;
+
+        Ok(())
+    }
+}
+
+impl Display for GitBackend {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Git: {}", &self.url)
+    }
+}
+
+// On Windows, this path corresponds to extended length path
+// which means we can only join backslash-delimited paths to it
+#[derive(Clone, Deserialize, Serialize)]
+pub struct LocalBackend {
+    origin: PathBuf,
+}
+
+impl LocalBackend {
+    pub fn new(origin: PathBuf) -> Self {
+        LocalBackend { origin }
+    }
+}
+
+#[typetag::serde]
+impl Backend for LocalBackend {
+    fn update_at(&self, local_path: &Path) -> SomaResult<()> {
+        if local_path.exists() {
+            remove_dir_all(local_path)?;
+        }
+
+        let mut copy_options = dir::CopyOptions::new();
+        copy_options.copy_inside = true;
+        dir::copy(&self.origin, local_path, &copy_options)?;
+
+        Ok(())
+    }
+}
+
+impl Display for LocalBackend {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Local: {}", self.origin.to_string_lossy())
+    }
+}

--- a/src/repository/manager.rs
+++ b/src/repository/manager.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use crate::data_dir::{DirectoryManager, Registration};
 use crate::prelude::*;
 use crate::problem::Problem;
-use crate::repository::backend::Backend;
+use crate::repository::backend::{Backend, BackendExt};
 use crate::repository::{read_prob_list, ProblemIndex, Repository};
 
 const INDEX_FILE_NAME: &str = "index";

--- a/src/repository/manager.rs
+++ b/src/repository/manager.rs
@@ -6,10 +6,11 @@ use std::path::{Path, PathBuf};
 use remove_dir_all::remove_dir_all;
 use serde::{Deserialize, Serialize};
 
-use super::{Backend, ProblemIndex, Repository};
 use crate::data_dir::{DirectoryManager, Registration};
 use crate::prelude::*;
 use crate::problem::Problem;
+use crate::repository::backend::Backend;
+use crate::repository::{read_prob_list, ProblemIndex, Repository};
 
 const INDEX_FILE_NAME: &str = "index";
 
@@ -19,7 +20,7 @@ fn index_path<'a>(registration: &Registration<'a, RepositoryManager<'a>>) -> Pat
 
 #[derive(Clone, Deserialize, Serialize)]
 struct Index {
-    backend: Backend,
+    backend: Box<dyn Backend>,
     prob_list: Vec<ProblemIndex>,
 }
 
@@ -62,21 +63,16 @@ impl<'a> RepositoryManager<'a> {
         self.root_path().join(repo_name)
     }
 
-    pub fn add_repo(&mut self, repo_name: String, backend: Backend) -> SomaResult<()> {
+    pub fn add_repo(&mut self, repo_name: String, backend: Box<dyn Backend>) -> SomaResult<()> {
         if self.repo_exists(&repo_name) {
             Err(SomaError::DuplicateRepository)?;
         } else {
             let temp_dir = tempfile::tempdir()?;
             backend.update_at(temp_dir.path())?;
-            let prob_list = super::read_prob_list(temp_dir.path())?;
+            let prob_list = read_prob_list(temp_dir.path())?;
 
-            self.repo_index.insert(
-                repo_name.clone(),
-                Index {
-                    backend: backend.clone(),
-                    prob_list,
-                },
-            );
+            self.repo_index
+                .insert(repo_name.clone(), Index { backend, prob_list });
             self.dirty = true;
         }
 

--- a/tests/location_to_backend.rs
+++ b/tests/location_to_backend.rs
@@ -1,30 +1,12 @@
-use soma::ops::location_to_backend;
-use soma::repository::Backend;
+use soma::repository::backend::location_to_backend;
 
 pub use self::common::*;
 
 mod common;
 
-fn test_parse_git(location: &str, expected_repo_name: &str) {
-    assert!(
-        if let Ok((repo_name, Backend::GitBackend(_))) = location_to_backend(location) {
-            assert_eq!(repo_name, expected_repo_name);
-            true
-        } else {
-            false
-        }
-    );
-}
-
-fn test_parse_local(location: &str, expected_repo_name: &str) {
-    assert!(
-        if let Ok((repo_name, Backend::LocalBackend(_))) = location_to_backend(location) {
-            assert_eq!(repo_name, expected_repo_name);
-            true
-        } else {
-            false
-        }
-    );
+fn test_parse(location: &str, expected_repo_name: &str) {
+    let (repo_name, _) = location_to_backend(location).expect("failed to parse the location");
+    assert_eq!(repo_name, expected_repo_name);
 }
 
 fn test_parse_fail(location: &str) {
@@ -33,11 +15,13 @@ fn test_parse_fail(location: &str) {
 
 #[test]
 fn location_to_backend_success() {
-    test_parse_git(SIMPLE_BOF_GIT, SIMPLE_BOF_REPO_NAME);
-    test_parse_git(BATA_LIST_GIT, BATA_LIST_REPO_NAME);
+    test_parse(SIMPLE_BOF_GIT, SIMPLE_BOF_REPO_NAME);
+    test_parse(BATA_LIST_GIT, BATA_LIST_REPO_NAME);
     // TODO: git through other protocols
     // test_parse_git("git@github.com:PLUS-POSTECH/simple-bof.git", SIMPLE_BOF_REPO_NAME);
-    test_parse_local("hooks", "hooks");
+
+    test_parse("ci", "ci");
+    test_parse("tests/common", "common");
 }
 
 #[test]

--- a/tests/location_to_backend.rs
+++ b/tests/location_to_backend.rs
@@ -4,9 +4,16 @@ pub use self::common::*;
 
 mod common;
 
-fn test_parse(location: &str, expected_repo_name: &str) {
-    let (repo_name, _) = location_to_backend(location).expect("failed to parse the location");
+fn test_parse_git(location: &str, expected_repo_name: &str) {
+    let (repo_name, backend) = location_to_backend(location).expect("failed to parse the location");
     assert_eq!(repo_name, expected_repo_name);
+    assert!(backend.to_string().starts_with("Git"));
+}
+
+fn test_parse_local(location: &str, expected_repo_name: &str) {
+    let (repo_name, backend) = location_to_backend(location).expect("failed to parse the location");
+    assert_eq!(repo_name, expected_repo_name);
+    assert!(backend.to_string().starts_with("Local"));
 }
 
 fn test_parse_fail(location: &str) {
@@ -15,13 +22,13 @@ fn test_parse_fail(location: &str) {
 
 #[test]
 fn location_to_backend_success() {
-    test_parse(SIMPLE_BOF_GIT, SIMPLE_BOF_REPO_NAME);
-    test_parse(BATA_LIST_GIT, BATA_LIST_REPO_NAME);
+    test_parse_git(SIMPLE_BOF_GIT, SIMPLE_BOF_REPO_NAME);
+    test_parse_git(BATA_LIST_GIT, BATA_LIST_REPO_NAME);
     // TODO: git through other protocols
     // test_parse_git("git@github.com:PLUS-POSTECH/simple-bof.git", SIMPLE_BOF_REPO_NAME);
 
-    test_parse("ci", "ci");
-    test_parse("tests/common", "common");
+    test_parse_local("ci", "ci");
+    test_parse_local("tests/common", "common");
 }
 
 #[test]


### PR DESCRIPTION
**Warning! This PR changes index structure. You should delete your `.soma` directory once this PR is merged.**

Resolves #100.

While working on this PR, I found that Rust's trait object is much more restrictive than Enum. I think we should discuss whether #100 is a right way to go or not. Using trait object is better if we are going to support more Backends in the future, but in the current status (git and local backend) I felt like it is a little bit premature abstraction.